### PR TITLE
Move stored properties from 'SubtitleFormat' to 'Subtitle' struct

### DIFF
--- a/Napi.xcodeproj/project.pbxproj
+++ b/Napi.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		20176E931C6A502500574B5B /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20176E921C6A502500574B5B /* Timestamp.swift */; };
 		208625CB1D4513A800B6DEF6 /* Int+Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208625CA1D4513A800B6DEF6 /* Int+Timestamp.swift */; };
 		209FA9671D2FE4FD00C54DCA /* TokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209FA9661D2FE4FD00C54DCA /* TokenTests.swift */; };
+		20A76D701D47D94F00BC031B /* Subtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A76D6F1D47D94F00BC031B /* Subtitle.swift */; };
 		20C989691D36A92C00B16DD2 /* LexerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209FA95F1D2FC04D00C54DCA /* LexerTests.swift */; };
 		20C9896E1D36AB3100B16DD2 /* SubtitleTokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F105C11D3114A2000E157F /* SubtitleTokenType.swift */; };
 		20EF7CFC1C67B1C4005A17A7 /* MicroDVDSubtitleFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EF7CFB1C67B1C4005A17A7 /* MicroDVDSubtitleFormat.swift */; };
@@ -69,6 +70,7 @@
 		208625CA1D4513A800B6DEF6 /* Int+Timestamp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Int+Timestamp.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		209FA95F1D2FC04D00C54DCA /* LexerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LexerTests.swift; sourceTree = "<group>"; };
 		209FA9661D2FE4FD00C54DCA /* TokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenTests.swift; sourceTree = "<group>"; };
+		20A76D6F1D47D94F00BC031B /* Subtitle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subtitle.swift; sourceTree = "<group>"; };
 		20EF7CFB1C67B1C4005A17A7 /* MicroDVDSubtitleFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MicroDVDSubtitleFormat.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		20EF7CFE1C67B280005A17A7 /* MicroDVDSubtitleFormatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MicroDVDSubtitleFormatTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		20F105C11D3114A2000E157F /* SubtitleTokenType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtitleTokenType.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				20F105C11D3114A2000E157F /* SubtitleTokenType.swift */,
 				20176E921C6A502500574B5B /* Timestamp.swift */,
 				200364F71CFE0EF800A09CEA /* Token.swift */,
+				20A76D6F1D47D94F00BC031B /* Subtitle.swift */,
 			);
 			path = "Subtitle Format";
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				20176E931C6A502500574B5B /* Timestamp.swift in Sources */,
 				200364F61CFE0EEA00A09CEA /* Lexer.swift in Sources */,
 				200C4BA81C66552500FBE406 /* TMPlayerSubtitleFormat.swift in Sources */,
+				20A76D701D47D94F00BC031B /* Subtitle.swift in Sources */,
 				20C9896E1D36AB3100B16DD2 /* SubtitleTokenType.swift in Sources */,
 				200780CB1C64F3BC0098B026 /* SubRipSubtitleFormat.swift in Sources */,
 				200364F81CFE0EF800A09CEA /* Token.swift in Sources */,

--- a/Napi/Models/Helpers/Int+Timestamp.swift
+++ b/Napi/Models/Helpers/Int+Timestamp.swift
@@ -31,3 +31,12 @@ extension Int {
         return Timestamp(value: self, unit: .frames(frameRate: frameRate))
     }
 }
+
+extension Int {
+
+    /// Converts an `Int` into  a `String` and adds
+    /// specified number of leadins zeros as a prefix.
+    func toString(leadingZeros: Int) -> String {
+        return String(format: "%0\(leadingZeros)d", self)
+    }
+}

--- a/Napi/Models/Subtitle Format/Subtitle.swift
+++ b/Napi/Models/Subtitle Format/Subtitle.swift
@@ -1,0 +1,23 @@
+//
+//  Subtitle.swift
+//  Napi
+//
+//  Created by Mateusz Karwat on 26/07/16.
+//  Copyright © 2016 Mateusz Karwat. All rights reserved.
+//
+
+/// Represents a single subtitle (entry) which appears
+/// on a screen at specified time.
+struct Subtitle {
+
+    /// Represents a timestamp that tells when subtitle
+    /// should appear on a screen.
+    var startTimestamp: Timestamp
+
+    /// Represents a timestamp that tells when subtitle
+    /// should disappear from a screen.
+    var stopTimestamp: Timestamp
+
+    /// Represents a text which is displayed on a screen.
+    var text: String
+}

--- a/Napi/Models/Subtitle Format/SubtitleFormat.swift
+++ b/Napi/Models/Subtitle Format/SubtitleFormat.swift
@@ -11,34 +11,23 @@ import Foundation
 /// Requirements for types that are a subtitle format.
 protocol SubtitleFormat {
 
-    /// Represents a timestamp that tells when subtitle
-    /// should appear on a screen.
-    var startTimestamp: Timestamp { get set }
-
-    /// Represents a timestamp that tells when subtitle
-    /// should disappear from a screen.
-    var stopTimestamp: Timestamp { get set }
-
-    /// Represents a text (subtitle) which is displayed on a screen.
-    var text: String { get set }
-
     /// A regular expression that represents a syntax (format)
     /// of a specific subtitle format.
     static var regexPattern: String { get }
 
-    /// Function which returns an instance of subtitle format
+    /// Function which returns an instance of a subtitle.
     /// if given `String` matches `regexPattern`. Returns `nil` otherwise.
-    static func decode(_ aString: String) -> Self?
+    static func decode(_ aString: String) -> Subtitle?
 
     /// Returns a `String` which represents specific implementation
     /// of a subtitle format. This `String` must be in a format
     /// that is stored in a subtitle file. Must include all tags,
     /// formatters and timestamps required by file format.
-    func stringValue() -> String
+    static func encode(_ subtitles: [Subtitle]) -> [String]
 
     /// Returns `String` representation of a given `Token`.
     /// If a given `Token` is not supported, it should return a `nil`.
-    func stringValue(for token: Token<SubtitleTokenType>) -> String?
+    static func stringValue(for token: Token<SubtitleTokenType>) -> String?
 }
 
 extension SubtitleFormat {
@@ -74,7 +63,7 @@ extension SubtitleFormat {
 extension SubtitleFormat {
 
     // Default implementation of all subtitle token types.
-    func stringValue(for token: Token<SubtitleTokenType>) -> String? {
+    static func stringValue(for token: Token<SubtitleTokenType>) -> String? {
         switch token.type {
         case .boldStart:        return "{y:b}"
         case .boldEnd:          return "{/y:b}"
@@ -89,18 +78,5 @@ extension SubtitleFormat {
         case .word:             return "\(token.lexeme)"
         case .unknownCharacter: return "\(token.lexeme)"
         }
-    }
-}
-
-/// Represents all supported subtitle formats by this application.
-enum SupportedSubtitleFormat {
-    case mpl2
-    case microDVD
-    case subRip
-    case tmplayer
-
-    /// Returns a sequence with all supported subtitle formats.
-    var allSupportedSubtitleFormats: [SupportedSubtitleFormat] {
-        return [mpl2, microDVD, subRip, tmplayer]
     }
 }

--- a/Napi/Models/Subtitle Format/Supported Subtitle Formats/MPL2SubtitleFormat.swift
+++ b/Napi/Models/Subtitle Format/Supported Subtitle Formats/MPL2SubtitleFormat.swift
@@ -13,14 +13,9 @@ import Foundation
 ///
 ///     [111][222]First line of a text.|Seconds line of a text.
 struct MPL2SubtitleFormat: SubtitleFormat {
-    var startTimestamp: Timestamp
-    var stopTimestamp: Timestamp
-    
-    var text: String
-
     static let regexPattern = "\\[(\\d+)\\]\\[(\\d+)\\](.+)"
 
-    static func decode(_ aString: String) -> MPL2SubtitleFormat? {
+    static func decode(_ aString: String) -> Subtitle? {
         guard
             let substrings = MPL2SubtitleFormat.capturedSubstrings(from: aString),
             let startStamp = Int(substrings[0])?.deciseconds,
@@ -29,15 +24,21 @@ struct MPL2SubtitleFormat: SubtitleFormat {
                 return nil
         }
 
-        return MPL2SubtitleFormat(startTimestamp: startStamp,
-                                  stopTimestamp: stopStamp,
-                                  text: substrings[2])
+        return Subtitle(startTimestamp: startStamp,
+                        stopTimestamp: stopStamp,
+                        text: substrings[2])
     }
 
-    func stringValue() -> String {
-        return
-            "[\(startTimestamp.roundedValue(in: .deciseconds))]" +
-            "[\(stopTimestamp.roundedValue(in: .deciseconds))]" +
-            "\(text)"
+    static func encode(_ subtitles: [Subtitle]) -> [String] {
+        var encodedSubtitles = [String]()
+
+        for subtitle in subtitles {
+            encodedSubtitles.append(
+                "[\(subtitle.startTimestamp.roundedValue(in: .deciseconds))]" +
+                "[\(subtitle.stopTimestamp.roundedValue(in: .deciseconds))]" +
+                "\(subtitle.text)")
+        }
+
+        return encodedSubtitles
     }
 }

--- a/Napi/Models/Subtitle Format/Supported Subtitle Formats/TMPlayerSubtitleFormat.swift
+++ b/Napi/Models/Subtitle Format/Supported Subtitle Formats/TMPlayerSubtitleFormat.swift
@@ -13,14 +13,9 @@ import Foundation
 ///
 ///     01:12:33:First line of a text.|Seconds line of a text.
 struct TMPlayerSubtitleFormat: SubtitleFormat {
-    var startTimestamp: Timestamp
-    var stopTimestamp: Timestamp
-    
-    var text: String
-    
     static let regexPattern = "(\\d{1,2}):(\\d{1,2}):(\\d{1,2}):(.+)"
 
-    static func decode(_ aString: String) -> TMPlayerSubtitleFormat? {
+    static func decode(_ aString: String) -> Subtitle? {
         guard
             let substrings = TMPlayerSubtitleFormat.capturedSubstrings(from: aString),
             let hours = Int(substrings[0])?.hours,
@@ -32,25 +27,29 @@ struct TMPlayerSubtitleFormat: SubtitleFormat {
 
         let timestamp = hours + minutes + seconds
 
-        return TMPlayerSubtitleFormat(startTimestamp: timestamp,
-                                      stopTimestamp: timestamp + 5.seconds,
-                                      text: substrings[3])
+        return Subtitle(startTimestamp: timestamp,
+                        stopTimestamp: timestamp + 5.seconds,
+                        text: substrings[3])
     }
-    
-    func stringValue() -> String {
-        return "\(stringFormatForSubtitleTime(startTimestamp)):\(text)"
+
+    static func encode(_ subtitles: [Subtitle]) -> [String] {
+        var encodedSubtitles = [String]()
+
+        for subtitle in subtitles {
+            encodedSubtitles.append("\(subtitle.startTimestamp.stringFormat()):\(subtitle.text)")
+        }
+
+        return encodedSubtitles
     }
 }
 
-extension TMPlayerSubtitleFormat {
-
-    /// Returns `Timestamp` as a `String` that is compatible with TMPlayer format.
-    private func stringFormatForSubtitleTime(_ timestamp: Timestamp)  -> String {
-        let minutes = timestamp - Timestamp(value: timestamp.numberOfFull(.hours), unit: .hours)
+private extension Timestamp {
+    func stringFormat() -> String {
+        let minutes = self - Timestamp(value: self.numberOfFull(.hours), unit: .hours)
         let seconds = minutes - Timestamp(value: minutes.numberOfFull(.minutes), unit: .minutes)
 
         return
-            "\(timestamp.numberOfFull(.hours).toString(leadingZeros: 2)):" +
+            "\(self.numberOfFull(.hours).toString(leadingZeros: 2)):" +
             "\(minutes.numberOfFull(.minutes).toString(leadingZeros: 2)):" +
             "\(seconds.numberOfFull(.seconds).toString(leadingZeros: 2))"
     }

--- a/Napi/Models/Subtitle Format/Timestamp.swift
+++ b/Napi/Models/Subtitle Format/Timestamp.swift
@@ -116,6 +116,17 @@ struct Timestamp {
     }
 }
 
+extension Timestamp {
+
+    /// Checks if `Timestamps` unit is based on frames.
+    var isFrameBased: Bool {
+        if case .frames(frameRate: _) = self.unit {
+            return true
+        }
+        return false
+    }
+}
+
 // MARK: Arithmetic Operators
 
 /// Returns new `Timestamp` which is a result of adding `baseValues`

--- a/NapiTests/Subtitle Formats/MPL2SubtitleFormatTests.swift
+++ b/NapiTests/Subtitle Formats/MPL2SubtitleFormatTests.swift
@@ -12,21 +12,21 @@ import XCTest
 class MPL2SubtitleFormatTests: XCTestCase {
     
     func testStringValue() {
-        let mplFormat = MPL2SubtitleFormat(startTimestamp: 99_100.milliseconds,
-                                           stopTimestamp: 100_000.milliseconds,
-                                           text: "Test.")
+        let subtitle = Subtitle(startTimestamp: 99_100.milliseconds,
+                                stopTimestamp: 100_000.milliseconds,
+                                text: "Test.")
 
-        XCTAssertEqual(mplFormat.stringValue(), "[991][1000]Test.")
+        XCTAssertEqual(MPL2SubtitleFormat.encode([subtitle]), ["[991][1000]Test."])
     }
 
     func testDecodeCorrectInput() {
         let input = "[1][9999]Test."
 
-        let mplFormat = MPL2SubtitleFormat.decode(input)
+        let decodedSubtitle = MPL2SubtitleFormat.decode(input)
 
-        XCTAssertEqual(mplFormat?.startTimestamp.baseValue, 100)
-        XCTAssertEqual(mplFormat?.stopTimestamp.baseValue, 999_900)
-        XCTAssertEqual(mplFormat?.text, "Test.")
+        XCTAssertEqual(decodedSubtitle?.startTimestamp.baseValue, 100)
+        XCTAssertEqual(decodedSubtitle?.stopTimestamp.baseValue, 999_900)
+        XCTAssertEqual(decodedSubtitle?.text, "Test.")
     }
 
     func testDecodeIncorrectInput() {

--- a/NapiTests/Subtitle Formats/MicroDVDSubtitleFormatTests.swift
+++ b/NapiTests/Subtitle Formats/MicroDVDSubtitleFormatTests.swift
@@ -12,21 +12,21 @@ import XCTest
 class MicroDVDSubtitleFormatTests: XCTestCase {
 
     func testStringValue() {
-        let microDVDFormat = MicroDVDSubtitleFormat(startTimestamp: 0.frames(frameRate: 1.0),
-                                                    stopTimestamp: 250.frames(frameRate: 1.0),
-                                                    text: "Simple one line of a text")
+        let subtitle = Subtitle(startTimestamp: 0.frames(frameRate: 1.0),
+                                stopTimestamp: 250.frames(frameRate: 1.0),
+                                text: "Simple one line of a text")
 
-        XCTAssertEqual(microDVDFormat.stringValue(), "{0}{250}Simple one line of a text")
+        XCTAssertEqual(MicroDVDSubtitleFormat.encode([subtitle]), ["{0}{250}Simple one line of a text"])
     }
 
     func testDecodeCorrectInput() {
         let input = "{0}{100}Simple one line of a text"
 
-        let microDVDFormat = MicroDVDSubtitleFormat.decode(input)
+        let decodedSubtitle = MicroDVDSubtitleFormat.decode(input)
 
-        XCTAssertEqual(microDVDFormat?.startTimestamp.numberOfFull(.milliseconds), 0)
-        XCTAssertEqual(microDVDFormat?.stopTimestamp.numberOfFull(.milliseconds), 4_170)
-        XCTAssertEqual(microDVDFormat?.text, "Simple one line of a text")
+        XCTAssertEqual(decodedSubtitle?.startTimestamp.numberOfFull(.milliseconds), 0)
+        XCTAssertEqual(decodedSubtitle?.stopTimestamp.numberOfFull(.milliseconds), 100_000)
+        XCTAssertEqual(decodedSubtitle?.text, "Simple one line of a text")
     }
 
     func testDecodeIncorrectInput() {

--- a/NapiTests/Subtitle Formats/SubRipSubtitleFormatTests.swift
+++ b/NapiTests/Subtitle Formats/SubRipSubtitleFormatTests.swift
@@ -15,18 +15,17 @@ class SubRipSubtitleFormatTests: XCTestCase {
         let startTimestamp = 1.hours + 2.minutes + 3.seconds + 4.milliseconds
         let stopTimestamp = 2.hours + 3.minutes + 33.seconds + 40.milliseconds
         
-        let subRipFormat = SubRipSubtitleFormat(textNumber: 2,
-                                                startTimestamp: startTimestamp,
-                                                stopTimestamp: stopTimestamp,
-                                                text: "You know nothing!\nJohn Snow...")
+        let subtitle = Subtitle(startTimestamp: startTimestamp,
+                                stopTimestamp: stopTimestamp,
+                                text: "You know nothing!\nJohn Snow...")
 
         let expectedStringValue =
-            "2\n" +
+            "1\n" +
             "01:02:03,004 --> 02:03:33,040\n" +
             "You know nothing!\n" +
             "John Snow...\n"
 
-        XCTAssertEqual(subRipFormat.stringValue(), expectedStringValue)
+        XCTAssertEqual(SubRipSubtitleFormat.encode([subtitle]), [expectedStringValue])
     }
     
     func testDecodeCorrectInput() {
@@ -38,15 +37,14 @@ class SubRipSubtitleFormatTests: XCTestCase {
             "\n"
 
 
-        let srtFormat = SubRipSubtitleFormat.decode(input)
+        let decodedSubtitle = SubRipSubtitleFormat.decode(input)
 
         let startTimestamp = 1.hours + 2.minutes + 3.seconds + 4.milliseconds
         let stopTimestamp = 2.hours + 3.minutes + 33.seconds + 40.milliseconds
 
-        XCTAssertEqual(srtFormat?.textNumber, 2)
-        XCTAssertEqual(srtFormat?.startTimestamp.baseValue, startTimestamp.baseValue)
-        XCTAssertEqual(srtFormat?.stopTimestamp.baseValue, stopTimestamp.baseValue)
-        XCTAssertEqual(srtFormat?.text, "You know nothing!\nJohn Snow...")
+        XCTAssertEqual(decodedSubtitle?.startTimestamp.baseValue, startTimestamp.baseValue)
+        XCTAssertEqual(decodedSubtitle?.stopTimestamp.baseValue, stopTimestamp.baseValue)
+        XCTAssertEqual(decodedSubtitle?.text, "You know nothing!\nJohn Snow...")
     }
 
     func testDecodeIncorrectInput() {

--- a/NapiTests/Subtitle Formats/TMPlayerSubtitleFormatTests.swift
+++ b/NapiTests/Subtitle Formats/TMPlayerSubtitleFormatTests.swift
@@ -12,21 +12,22 @@ import XCTest
 class TMPlayerSubtitleFormatTests: XCTestCase {
     
     func testTMPLayerSubtitleFormatStringValue() {
-        let tmplayerFormat = TMPlayerSubtitleFormat(startTimestamp: 3_671_000.milliseconds,
-                                                    stopTimestamp: 7_271_000.milliseconds,
-                                                    text: "A long time ago...|In a galaxy far far away...")
+        let subtitle = Subtitle(startTimestamp: 3_671_000.milliseconds,
+                                stopTimestamp: 7_271_000.milliseconds,
+                                text: "A long time ago...|In a galaxy far far away...")
 
-        XCTAssertEqual(tmplayerFormat.stringValue(), "01:01:11:A long time ago...|In a galaxy far far away...")
+        XCTAssertEqual(TMPlayerSubtitleFormat.encode([subtitle]),
+                       ["01:01:11:A long time ago...|In a galaxy far far away..."])
     }
 
     func testDecodeCorrectInput() {
         let input = "01:01:11:A long time ago...|In a galaxy far far away..."
 
-        let tmplayerFormat = TMPlayerSubtitleFormat.decode(input)
+        let decodedSubtitle = TMPlayerSubtitleFormat.decode(input)
 
-        XCTAssertEqual(tmplayerFormat?.startTimestamp.baseValue, 3_671_000)
-        XCTAssertEqual(tmplayerFormat?.stopTimestamp.baseValue, 3_676_000)
-        XCTAssertEqual(tmplayerFormat?.text, "A long time ago...|In a galaxy far far away...")
+        XCTAssertEqual(decodedSubtitle?.startTimestamp.baseValue, 3_671_000)
+        XCTAssertEqual(decodedSubtitle?.stopTimestamp.baseValue, 3_676_000)
+        XCTAssertEqual(decodedSubtitle?.text, "A long time ago...|In a galaxy far far away...")
     }
 
     func testDecodeIncorrectInput() {

--- a/NapiTests/TimestampTests.swift
+++ b/NapiTests/TimestampTests.swift
@@ -123,4 +123,13 @@ class TimestampTests: XCTestCase {
         XCTAssertEqual(61.minutes.roundedValue(in: .hours), 1)
     }
 
+    func testIsFrameBased() {
+        XCTAssertTrue(25.frames(frameRate: 25).isFrameBased)
+
+        XCTAssertFalse(10.milliseconds.isFrameBased)
+        XCTAssertFalse(10.deciseconds.isFrameBased)
+        XCTAssertFalse(10.seconds.isFrameBased)
+        XCTAssertFalse(10.minutes.isFrameBased)
+        XCTAssertFalse(10.hours.isFrameBased)
+    }
 }


### PR DESCRIPTION
Stored properties in 'SubtitleFormat' were a bit problematic, so now they are moved to 'Subtitle' struct.
'SubtitleFormat' protocol no longer translates self into string value. Now it has to provide encoded value for given 'Subtitles'.
Unit tests were updated to reflect those changes.
